### PR TITLE
Implement `CommandEnum` to improve code quality

### DIFF
--- a/src/main/java/yorm/enums/CommandEnum.java
+++ b/src/main/java/yorm/enums/CommandEnum.java
@@ -1,0 +1,15 @@
+package yorm.enums;
+
+/**
+ * Enum representing the different enum types
+ */
+public enum CommandEnum {
+    AddCommand,
+    MarkCommand,
+    DeleteCommand,
+    FindCommand,
+    ExitCommand,
+    ListCommand,
+    YormException,
+    Default
+}

--- a/src/main/java/yorm/task/Task.java
+++ b/src/main/java/yorm/task/Task.java
@@ -75,7 +75,6 @@ public abstract class Task {
         Task task;
         String[] split = string.split(" \\| ");
         try {
-
             switch (split[0]) {
             case "T" -> {
                 if (split.length != 3) {

--- a/src/main/java/yorm/yormfxml/DialogBox.java
+++ b/src/main/java/yorm/yormfxml/DialogBox.java
@@ -13,6 +13,7 @@ import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
+import yorm.enums.CommandEnum;
 
 /**
  * Represents a dialog box consisting of an ImageView to represent the speaker's face
@@ -49,19 +50,19 @@ public class DialogBox extends HBox {
         this.dialog.getStyleClass().add("reply-label");
     }
 
-    private void changeDialogStyle(String commandType) {
+    private void changeDialogStyle(CommandEnum commandType) {
         switch(commandType) {
-        case "AddCommand":
-            dialog.getStyleClass().add("add-label");
+        case CommandEnum.AddCommand:
+            this.dialog.getStyleClass().add("add-label");
             break;
-        case "ChangeMarkCommand":
-            dialog.getStyleClass().add("marked-label");
+        case CommandEnum.MarkCommand:
+            this.dialog.getStyleClass().add("marked-label");
             break;
-        case "DeleteCommand":
-            dialog.getStyleClass().add("delete-label");
+        case CommandEnum.DeleteCommand:
+            this.dialog.getStyleClass().add("delete-label");
             break;
-        case "YormException":
-            dialog.getStyleClass().add("error-label");
+        case CommandEnum.YormException:
+            this.dialog.getStyleClass().add("error-label");
             break;
         default:
             // Do nothing
@@ -72,7 +73,7 @@ public class DialogBox extends HBox {
         return new DialogBox(text, img);
     }
 
-    public static DialogBox getYormDialog(String text, Image img, String commandType) {
+    public static DialogBox getYormDialog(String text, Image img, CommandEnum commandType) {
         var db = new DialogBox(text, img);
         db.flip();
         db.changeDialogStyle(commandType);

--- a/src/main/java/yorm/yormfxml/MainWindow.java
+++ b/src/main/java/yorm/yormfxml/MainWindow.java
@@ -7,6 +7,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
+import yorm.enums.CommandEnum;
 import yorm.yormjava.Yorm;
 
 /**
@@ -45,7 +46,7 @@ public class MainWindow extends AnchorPane {
     private void handleUserInput() {
         String input = userInput.getText();
         String response = yorm.getResponse(input);
-        String commandType = yorm.getCommandType();
+        CommandEnum commandType = yorm.getCommandType();
         this.dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, this.userImage),
                 DialogBox.getYormDialog(response, this.yormImage, commandType)

--- a/src/main/java/yorm/yormjava/Yorm.java
+++ b/src/main/java/yorm/yormjava/Yorm.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
 import yorm.command.Command;
+import yorm.enums.CommandEnum;
 import yorm.exception.YormException;
 import yorm.parser.Parser;
 import yorm.storage.Storage;
@@ -91,7 +92,11 @@ public class Yorm {
         }
     }
 
-    public String getCommandType() {
-        return this.commandType;
+    public CommandEnum getCommandType() {
+        try {
+            return CommandEnum.valueOf(this.commandType);
+        } catch (IllegalArgumentException e) {
+            return CommandEnum.Default;
+        }
     }
 }


### PR DESCRIPTION
Uses `CommandEnum` `Enum` instead of hardcoded strings for styling of dialog box